### PR TITLE
Updating packages

### DIFF
--- a/src/RepoAutomation.Tests/RepoAutomation.Tests.csproj
+++ b/src/RepoAutomation.Tests/RepoAutomation.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">


### PR DESCRIPTION
This pull request updates the `Microsoft.NET.Test.Sdk` package version from `17.7.2` to `17.8.0` for running unit tests in the `RepoAutomation.Tests.csproj` file.

* <a href="diffhunk://#diff-9f7683d7967e22058a723ad44036c4003bf1083e68485ed66c5317cbec9e555fL18-R18">`src/RepoAutomation.Tests/RepoAutomation.Tests.csproj`</a>: Updated `Microsoft.NET.Test.Sdk` package version from `17.7.2` to `17.8.0` for running unit tests.