### PR TITLE
Updated .net sample version

### DIFF
--- a/dependabotSamples/dotnet/Dotnet.csproj
+++ b/dependabotSamples/dotnet/Dotnet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
This pull request updates the target framework version of a .NET project from `net7.0` to `net8.0` in the `Dotnet.csproj` file, allowing the project to be built using .NET 5 runtime with new features and improvements.

Main interface changes:

* <a href="diffhunk://#diff-2cbbed445f175e0f998f77bcbc7fc893a4f14df368f2bb32c39517a14615ecddL4-R4">`dependabotSamples/dotnet/Dotnet.csproj`</a>: Updated target framework version from `net7.0` to `net8.0`, allowing the project to be built using .NET 5 runtime with new features and improvements.