### PR TITLE
Package updates

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,18 +18,18 @@ jobs:
       with:
         fetch-depth: 0 #fetch-depth is needed for GitVersion
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.10.2
+      uses: gittools/actions/gitversion/setup@v1.1.1
       with:
         versionSpec: 5.x
     - name: Determine Version
-      uses: gittools/actions/gitversion/execute@v0.10.2
+      uses: gittools/actions/gitversion/execute@v1.1.1
       id: gitversion # step id used as reference for output values
     - name: Display GitVersion outputs
       run: |
         echo "Version: ${{ steps.gitversion.outputs.SemVer }}"
         echo "CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersionSource }}"
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
     - name: Variable Substitution appsettings file for tests
@@ -72,7 +72,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4   
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
     #- name: Create directory for channel
@@ -95,7 +95,7 @@ jobs:
       if: runner.OS == 'Linux' #Only pack the Linux nuget package
       run: dotnet pack src/RepoAutomation.Core/RepoAutomation.Core.csproj -c Release --nologo --include-symbols -p:Version='${{ needs.versionAndTest.outputs.Version }}'
     - name: Upload nuget package back to GitHub
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: runner.OS == 'Linux' #Only pack the Linux nuget package
       with:
         name: nugetPackage
@@ -130,7 +130,7 @@ jobs:
         echo "Version: ${{ needs.versionAndTest.outputs.Version }}" 
         echo "CommitsSinceVersionSource: ${{ needs.versionAndTest.outputs.CommitsSinceVersionSource }}" 
     - name: Download package artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
     - name: Create Release
       uses: ncipollo/release-action@v1
       if: needs.versionAndTest.outputs.CommitsSinceVersionSource > 0 #Only create a release if there has been a commit/version change

--- a/src/RepoAutomation.Core/RepoAutomation.Core.csproj
+++ b/src/RepoAutomation.Core/RepoAutomation.Core.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GitHubActionsDotNet" Version="1.3.1" />
+		<PackageReference Include="GitHubActionsDotNet" Version="1.3.19" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 

--- a/src/RepoAutomation.Tests/RepoAutomation.Tests.csproj
+++ b/src/RepoAutomation.Tests/RepoAutomation.Tests.csproj
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/RepoAutomation.Tests/RepoTests.cs
+++ b/src/RepoAutomation.Tests/RepoTests.cs
@@ -234,7 +234,7 @@ public class RepoTests : BaseAPIAccessTests
 
         //Assert
         Assert.IsNotNull(commitSHA);
-        Assert.AreEqual("de6dd3a3812f0e4132bc2ef831e9fc13550aca0e", commitSHA);
+        Assert.AreEqual("2f31003da1cb671bb37fcb7efd1cd8c6a6529844", commitSHA);
     }
 
     [TestMethod]

--- a/src/RepoAutomation/RepoAutomation.csproj
+++ b/src/RepoAutomation/RepoAutomation.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="CommandLineParser" Version="2.9.1" />
-	  <PackageReference Include="GitHubActionsDotNet" Version="1.3.1" />
+	  <PackageReference Include="GitHubActionsDotNet" Version="1.3.19" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>


### PR DESCRIPTION
This pull request primarily focuses on updating various dependencies used in the `.github/workflows/dotnet.yml` workflow and in the `src/RepoAutomation.Core/RepoAutomation.Core.csproj`, `src/RepoAutomation.Tests/RepoAutomation.Tests.csproj`, and `src/RepoAutomation/RepoAutomation.csproj` project files. The updates include changes to the versions of GitVersion, .NET setup, artifact upload and download, and several NuGet packages.

Updates in `.github/workflows/dotnet.yml`:

* Updated GitVersion from version `0.10.2` to `1.1.1` in the Install GitVersion and Determine Version steps.
* Updated .NET setup from version `v3` to `v4` in the Setup .NET step. [[1]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L75-R75) [[2]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L21-R32)
* Updated artifact upload from version `v3` to `v4` in the Upload nuget package back to GitHub step.
* Updated artifact download from version `v3` to `v4` in the Download package artifacts step.

Updates in `src/RepoAutomation.Core/RepoAutomation.Core.csproj`, `src/RepoAutomation.Tests/RepoAutomation.Tests.csproj`, and `src/RepoAutomation/RepoAutomation.csproj`:

* Updated the `GitHubActionsDotNet` package from version `1.3.1` to `1.3.19`. [[1]](diffhunk://#diff-ce85740cafcdad575e436ca7473f38da3ec2612b229c983a31cca53676aad334L10-R10) [[2]](diffhunk://#diff-9a42cff54ca7931eaccc6de44d2b1de4111629cd0d3fafc30826978750f1f3b2L13-R13)
* Updated the `coverlet.msbuild` package from version `6.0.0` to `6.0.2` in the `RepoAutomation.Tests` project.
* Updated the `Microsoft.NET.Test.Sdk` package from version `17.8.0` to `17.9.0`, the `MSTest.TestAdapter` package from version `3.1.1` to `3.3.1`, and the `MSTest.TestFramework` package from version `3.1.1` to `3.3.1` in the `RepoAutomation.Tests` project.
* Updated the `coverlet.collector` package from version `6.0.0` to `6.0.2` in the `RepoAutomation.Tests` project.