### PR TITLE
Updated failure script

### DIFF
--- a/src/RepoAutomation.Core/APIAccess/GitHubApiAccess.cs
+++ b/src/RepoAutomation.Core/APIAccess/GitHubApiAccess.cs
@@ -25,7 +25,7 @@ public static class GitHubApiAccess
             string url = $"https://api.github.com/repos/{owner}/{repo}";
             string? response = await BaseApiAccess.GetGitHubMessage(url, clientId, clientSecret, false);
             if (!string.IsNullOrEmpty(response) &&
-                response != @"{""message"":""Not Found"",""documentation_url"":""https://docs.github.com/rest/repos/repos#get-a-repository""}")
+                response != @"{""message"":""Not Found"",""documentation_url"":""https://docs.github.com/rest/repos/repos#get-a-repository"",""status"":""404""}")
             {
                 dynamic? jsonObj = JsonConvert.DeserializeObject(response);
                 result = JsonConvert.DeserializeObject<Repo>(jsonObj?.ToString());


### PR DESCRIPTION
This pull request includes a change to the `GitHubApiAccess` class in the `src/RepoAutomation.Core/APIAccess/GitHubApiAccess.cs` file. The change modifies the condition to check for a 404 status in the response from the GitHub API, providing a more accurate way of handling not found errors.