### PR TITLE
Updates to GitVersion

### DIFF
--- a/src/RepoAutomation.Core/Helpers/GitHubActions.cs
+++ b/src/RepoAutomation.Core/Helpers/GitHubActions.cs
@@ -48,7 +48,7 @@ namespace RepoAutomation.Core.Helpers
             root.on = TriggerHelper.AddStandardPushAndPullTrigger("main");
 
             string displayBuildGitVersionScript = @"
-echo ""Version: ${{ steps.gitversion.outputs.SemVer }}""
+echo ""Version: ${{ steps.gitversion.outputs.MajorMinorPatch }}""
 echo ""CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersionSource }}""";
 
             List<Step> steps = new()
@@ -68,27 +68,27 @@ echo ""CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersi
                 }
                 else if (item.Value == "") //Console or library
                 {
-                    steps.Add(DotNetStepHelper.AddDotNetPublishStep(".NET publish", "src/" + projectName + "/" + projectName + item.Value + ".csproj", "Release", null, "-p:Version='${{ steps.gitversion.outputs.SemVer }}'", true));
+                    steps.Add(DotNetStepHelper.AddDotNetPublishStep(".NET publish", "src/" + projectName + "/" + projectName + item.Value + ".csproj", "Release", null, "-p:Version='${{ steps.gitversion.outputs.MajorMinorPatch }}'", true));
                     steps.Add(CommonStepHelper.AddUploadArtifactStep("Upload package back to GitHub", "drop", "src/" + projectName + item.Value + "/bin/Release"));
                 }
                 else if (item.Value == ".Web") //Website
                 {
-                    steps.Add(DotNetStepHelper.AddDotNetPublishStep(".NET publish", "src/" + projectName + item.Value + "/" + projectName + item.Value + ".csproj", "Release", null, "-p:Version='${{ steps.gitversion.outputs.SemVer }}'", true));
+                    steps.Add(DotNetStepHelper.AddDotNetPublishStep(".NET publish", "src/" + projectName + item.Value + "/" + projectName + item.Value + ".csproj", "Release", null, "-p:Version='${{ steps.gitversion.outputs.MajorMinorPatch }}'", true));
                     steps.Add(CommonStepHelper.AddUploadArtifactStep("Upload package back to GitHub", "web", "src/" + projectName + item.Value + "/bin/Release"));
                 }
                 else if (item.Value == ".Service") //Service
                 {
-                    steps.Add(DotNetStepHelper.AddDotNetPublishStep(".NET publish", "src/" + projectName + item.Value + "/" + projectName + item.Value + ".csproj", "Release", null, "-p:Version='${{ steps.gitversion.outputs.SemVer }}'", true));
+                    steps.Add(DotNetStepHelper.AddDotNetPublishStep(".NET publish", "src/" + projectName + item.Value + "/" + projectName + item.Value + ".csproj", "Release", null, "-p:Version='${{ steps.gitversion.outputs.MajorMinorPatch }}'", true));
                     steps.Add(CommonStepHelper.AddUploadArtifactStep("Upload package back to GitHub", "service", "src/" + projectName + item.Value + "/bin/Release"));
                 }
                 else if (item.Value == ".WPF") //WPF
                 {
-                    steps.Add(DotNetStepHelper.AddDotNetPublishStep(".NET publish", "src/" + projectName + "/" + projectName + item.Value + ".csproj", "Release", null, "-p:Version='${{ steps.gitversion.outputs.SemVer }}'", true));
+                    steps.Add(DotNetStepHelper.AddDotNetPublishStep(".NET publish", "src/" + projectName + "/" + projectName + item.Value + ".csproj", "Release", null, "-p:Version='${{ steps.gitversion.outputs.MajorMinorPatch }}'", true));
                     steps.Add(CommonStepHelper.AddUploadArtifactStep("Upload package back to GitHub", "wpf", "src/" + projectName + item.Value + "/bin/Release"));
                 }
                 else if (item.Value == ".Winforms") //Winforms
                 {
-                    steps.Add(DotNetStepHelper.AddDotNetPublishStep(".NET publish", "src/" + projectName + "/" + projectName + item.Value + ".csproj", "Release", null, "-p:Version='${{ steps.gitversion.outputs.SemVer }}'", true));
+                    steps.Add(DotNetStepHelper.AddDotNetPublishStep(".NET publish", "src/" + projectName + "/" + projectName + item.Value + ".csproj", "Release", null, "-p:Version='${{ steps.gitversion.outputs.MajorMinorPatch }}'", true));
                     steps.Add(CommonStepHelper.AddUploadArtifactStep("Upload package back to GitHub", "winforms", "src/" + projectName + item.Value + "/bin/Release"));
                 }
             }
@@ -101,7 +101,7 @@ echo ""CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersi
                 buildSteps);
             buildJob.outputs = new()
             {
-                { "Version", "${{ steps.gitversion.outputs.SemVer }}" },
+                { "Version", "${{ steps.gitversion.outputs.MajorMinorPatch }}" },
                 { "CommitsSinceVersionSource", "${{ steps.gitversion.outputs.CommitsSinceVersionSource }}" }
             };
             root.jobs.Add("build", buildJob);

--- a/src/RepoAutomation.Core/RepoAutomation.Core.csproj
+++ b/src/RepoAutomation.Core/RepoAutomation.Core.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GitHubActionsDotNet" Version="1.3.39" />
+		<PackageReference Include="GitHubActionsDotNet" Version="1.3.40" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 

--- a/src/RepoAutomation.Tests/ActionGenerationTests.cs
+++ b/src/RepoAutomation.Tests/ActionGenerationTests.cs
@@ -35,22 +35,22 @@ jobs:
     name: Build job
     runs-on: windows-latest
     outputs:
-      Version: ${{ steps.gitversion.outputs.SemVer }}
+      Version: ${{ steps.gitversion.outputs.MajorMinorPatch }}
       CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersionSource }}
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup GitVersion
-      uses: gittools/actions/gitversion/setup@v3.1.11
+      uses: gittools/actions/gitversion/setup@v4.01
       with:
-        versionSpec: 5.x
+        versionSpec: 6.x
     - name: Determine Version
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v3.1.11
+      uses: gittools/actions/gitversion/execute@v4.01
     - name: Display GitVersion outputs
       run: |
-        echo ""Version: ${{ steps.gitversion.outputs.SemVer }}""
+        echo ""Version: ${{ steps.gitversion.outputs.MajorMinorPatch }}""
         echo ""CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersionSource }}""
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
@@ -84,22 +84,22 @@ jobs:
     name: Build job
     runs-on: windows-latest
     outputs:
-      Version: ${{ steps.gitversion.outputs.SemVer }}
+      Version: ${{ steps.gitversion.outputs.MajorMinorPatch }}
       CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersionSource }}
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup GitVersion
-      uses: gittools/actions/gitversion/setup@v3.1.11
+      uses: gittools/actions/gitversion/setup@v4.0.1
       with:
-        versionSpec: 5.x
+        versionSpec: 6.x
     - name: Determine Version
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v3.1.11
+      uses: gittools/actions/gitversion/execute@v4.0.1
     - name: Display GitVersion outputs
       run: |
-        echo ""Version: ${{ steps.gitversion.outputs.SemVer }}""
+        echo ""Version: ${{ steps.gitversion.outputs.MajorMinorPatch }}""
         echo ""CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersionSource }}""
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
@@ -108,14 +108,14 @@ jobs:
     - name: .NET test
       run: dotnet test src/TestProject.Tests/TestProject.Tests.csproj -c Release
     - name: .NET publish
-      run: dotnet publish src/TestProject/TestProject.csproj -c Release -p:Version='${{ steps.gitversion.outputs.SemVer }}'
+      run: dotnet publish src/TestProject/TestProject.csproj -c Release -p:Version='${{ steps.gitversion.outputs.MajorMinorPatch }}'
     - name: Upload package back to GitHub
       uses: actions/upload-artifact@v4
       with:
         name: drop
         path: src/TestProject/bin/Release
     - name: .NET publish
-      run: dotnet publish src/TestProject.Web/TestProject.Web.csproj -c Release -p:Version='${{ steps.gitversion.outputs.SemVer }}'
+      run: dotnet publish src/TestProject.Web/TestProject.Web.csproj -c Release -p:Version='${{ steps.gitversion.outputs.MajorMinorPatch }}'
     - name: Upload package back to GitHub
       uses: actions/upload-artifact@v4
       with:

--- a/src/RepoAutomation.Tests/ActionGenerationTests.cs
+++ b/src/RepoAutomation.Tests/ActionGenerationTests.cs
@@ -42,12 +42,12 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup GitVersion
-      uses: gittools/actions/gitversion/setup@v4.01
+      uses: gittools/actions/gitversion/setup@v4.0.1
       with:
         versionSpec: 6.x
     - name: Determine Version
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v4.01
+      uses: gittools/actions/gitversion/execute@v4.0.1
     - name: Display GitVersion outputs
       run: |
         echo ""Version: ${{ steps.gitversion.outputs.MajorMinorPatch }}""

--- a/src/RepoAutomation/RepoAutomation.csproj
+++ b/src/RepoAutomation/RepoAutomation.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="CommandLineParser" Version="2.9.1" />
-	  <PackageReference Include="GitHubActionsDotNet" Version="1.3.39" />
+	  <PackageReference Include="GitHubActionsDotNet" Version="1.3.40" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.7" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow definitions used in the test suite to use newer versions of the GitVersion action and modifies the versioning scheme used for published artifacts. The main focus is on upgrading to GitVersion v4 and switching from the `SemVer` output to the more stable `MajorMinorPatch` output for versioning.